### PR TITLE
Enable DataDog APM

### DIFF
--- a/charts/lighthouse-githubapp/templates/deployment.yaml
+++ b/charts/lighthouse-githubapp/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/{{ .Chart.Name }}.logs: '[{"source":"go","service":"lighthouse-githubapp"}]'
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
@@ -67,6 +69,14 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+        - name: DD_ENABLED
+          value: "{{ .Values.datadog.enabled }}"
+        - name: DD_AGENT_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: DD_TRACE_AGENT_PORT
+          value: "{{ .Values.datadog.agentPort }}"
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:

--- a/charts/lighthouse-githubapp/values.yaml
+++ b/charts/lighthouse-githubapp/values.yaml
@@ -53,3 +53,7 @@ saasSA: vault:tekton-weasel/jx-tenant-service-saas-sa:json
 # github app support
 cert: vault:lh-github-app:cert
 id: vault:lh-github-app:id
+
+datadog:
+  enabled: true
+  agentPort: 8126

--- a/charts/preview/values.yaml
+++ b/charts/preview/values.yaml
@@ -25,3 +25,6 @@ preview:
   secret: vault:tekton-weasel/preview/jx-github-app:secret
   saasSA: vault:tekton-weasel/preview/jx-tenant-service-saas-sa:json
   debug: true
+  datadog:
+    enabled: false
+    agentPort: 8126

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/tektoncd/pipeline v0.5.1
+	gopkg.in/DataDog/dd-trace-go.v1 v1.19.0
 	k8s.io/apiextensions-apiserver v0.0.0-20190820064606-e49a3471dba5
 	k8s.io/apimachinery v0.0.0-20190816221834-a9f1d8a9c101
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Comcast/kuberhealthy v1.0.2/go.mod h1:p7vxXAD/F7WgDtcexe8rcWrm6ELLuiUF222zxgWVFas=
+github.com/DataDog/datadog-go v2.2.0+incompatible h1:V5BKkxACZLjzHjSgBbr2gvLA2Ae49yhc6CSY7MLy5k4=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20181009230506-ac834ce67862/go.mod h1:aJ4qN3TfrelA6NZ6AXsXRfmEVaYin3EDbSPJrKS8OXo=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20181008063305-d718d474c7c2 h1:XCMASpjZLfZHpFKaNYZkb5lNcnXBQvc5J/1K/FKeVTU=
@@ -635,6 +636,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+v
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/petergtz/pegomock v2.7.0+incompatible h1:42rJ5wIOBAg9OGdkLaPW9PlF/RtqDc5aGl6PcTCXl3o=
 github.com/petergtz/pegomock v2.7.0+incompatible/go.mod h1:nuBLWZpVyv/fLo56qTwt/AUau7jgouO1h7bEvZCq82o=
+github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v0.0.0-20181005164709-635575b42742/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
@@ -779,6 +781,7 @@ github.com/tektoncd/pipeline v0.5.1 h1:8722SzGr6TZyFL2D36RO16N5Llb1VL3hGWdnPYTgB
 github.com/tektoncd/pipeline v0.5.1/go.mod h1:IZzJdiX9EqEMuUcgdnElozdYYRh0/ZRC+NKMLj1K3Yw=
 github.com/tidwall/gjson v1.1.0/go.mod h1:c/nTNbUr0E0OrXEhq1pwa8iEgc2DOt4ZZqAt1HtCkPA=
 github.com/tidwall/match v0.0.0-20171002075945-1731857f09b1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -991,6 +994,7 @@ google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 gopkg.in/AlecAivazis/survey.v1 v1.8.3 h1:uf8V0NkfqJkwWF9mWziv/xkpVc31xgwftG7mXU7udHk=
 gopkg.in/AlecAivazis/survey.v1 v1.8.3/go.mod h1:iBNOmqKz/NUbZx3bA+4hAGLRC7fSK7tgtVDT4tB22XA=
+gopkg.in/DataDog/dd-trace-go.v1 v1.19.0 h1:aFSFd6oDMdvPYiToGqTv7/ERA6QrPhGaXSuueRCaM88=
 gopkg.in/DataDog/dd-trace-go.v1 v1.19.0/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/main.go
+++ b/main.go
@@ -6,8 +6,9 @@ import (
 	"github.com/cloudbees/lighthouse-githubapp/pkg/flags"
 	"github.com/cloudbees/lighthouse-githubapp/pkg/hook"
 	"github.com/cloudbees/lighthouse-githubapp/pkg/version"
-	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
+	muxtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"net/http"
 	"os"
 	"os/signal"
@@ -26,7 +27,12 @@ func main() {
 
 	logrus.Info("Lighthouse GitHub App is starting")
 
-	router := mux.NewRouter()
+	if flags.DataDogEnabled.Value() {
+		tracer.Start()
+		defer tracer.Stop()
+	}
+
+	router := muxtrace.NewRouter(muxtrace.WithServiceName("lighthouse-githubapp"))
 
 	handler, err := hook.NewHook()
 	if err != nil {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -27,4 +27,7 @@ var (
 
 	// DebugLogging should we use debug level logging
 	DebugLogging = NewBoolFlag(false, "DEBUG_LOGGING")
+
+	// DataDogEnabled should we enable the Datadog tracing
+	DataDogEnabled = NewBoolFlag(false, "DD_ENABLED")
 )

--- a/pkg/hook/handle_webhook.go
+++ b/pkg/hook/handle_webhook.go
@@ -10,6 +10,7 @@ import (
 )
 
 func (o *HookOptions) handleWebHookRequests(w http.ResponseWriter, r *http.Request) {
+
 	if r.Method != http.MethodPost {
 		// liveness probe etc
 		logrus.WithField("method", r.Method).Debug("invalid http method so returning index")

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/cloudbees/lighthouse-githubapp/pkg/util"
 	"net/http"
 	"strings"
 
@@ -69,13 +70,13 @@ func (o *HookOptions) Handle(mux *muxtrace.Router) {
 
 // health returns either HTTP 204 if the service is healthy, otherwise nothing ('cos it's dead).
 func (o *HookOptions) health(w http.ResponseWriter, r *http.Request) {
-	logrus.Debug("Health check")
+	util.TraceLogger(r.Context()).Info("Health check")
 	w.WriteHeader(http.StatusNoContent)
 }
 
 // ready returns either HTTP 204 if the service is ready to serve requests, otherwise HTTP 503.
 func (o *HookOptions) ready(w http.ResponseWriter, r *http.Request) {
-	logrus.Debug("Ready check")
+	util.TraceLogger(r.Context()).Debug("Ready check")
 	if o.isReady() {
 		w.WriteHeader(http.StatusNoContent)
 	} else {
@@ -85,7 +86,7 @@ func (o *HookOptions) ready(w http.ResponseWriter, r *http.Request) {
 
 // setup handle the setup URL
 func (o *HookOptions) setup(w http.ResponseWriter, r *http.Request) {
-	logrus.Debug("setup")
+	util.TraceLogger(r.Context()).Debug("setup")
 
 	action := r.URL.Query().Get("setup_action")
 	installationID := r.URL.Query().Get("installation_id")
@@ -93,7 +94,7 @@ func (o *HookOptions) setup(w http.ResponseWriter, r *http.Request) {
 
 	_, err := w.Write([]byte(message))
 	if err != nil {
-		logrus.Debugf("failed to write the setup: %v", err)
+		util.TraceLogger(r.Context()).Debugf("failed to write the setup: %v", err)
 	}
 }
 
@@ -113,7 +114,8 @@ func (o *HookOptions) defaultHandler(w http.ResponseWriter, r *http.Request) {
 
 // getIndex returns a simple home page
 func (o *HookOptions) getIndex(w http.ResponseWriter, r *http.Request) {
-	logrus.Debug("GET index")
+	l := util.TraceLogger(r.Context())
+	l.Debug("GET index")
 	message := fmt.Sprintf(`Hello from Jenkins X Lighthouse version: %s
 
 For more information see: https://github.com/jenkins-x/lighthouse
@@ -121,7 +123,7 @@ For more information see: https://github.com/jenkins-x/lighthouse
 
 	_, err := w.Write([]byte(message))
 	if err != nil {
-		logrus.Debugf("failed to write the index: %v", err)
+		l.Debugf("failed to write the index: %v", err)
 	}
 }
 

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudbees/lighthouse-githubapp/pkg/flags"
 	"github.com/cloudbees/lighthouse-githubapp/pkg/hook/connectors"
 	"github.com/cloudbees/lighthouse-githubapp/pkg/schedulers"
-	"github.com/gorilla/mux"
 	"github.com/jenkins-x/go-scm/scm"
 	v1 "github.com/jenkins-x/jx/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx/pkg/client/clientset/versioned"
@@ -26,6 +25,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	muxtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 )
 
 type HookOptions struct {
@@ -56,7 +56,7 @@ func NewHook() (*HookOptions, error) {
 	}, nil
 }
 
-func (o *HookOptions) Handle(mux *mux.Router) {
+func (o *HookOptions) Handle(mux *muxtrace.Router) {
 	mux.Handle(GithubAppPath, http.HandlerFunc(o.githubApp.handleInstalledRequests))
 	mux.Handle(TestTokenPath, http.HandlerFunc(o.handleTokenValid))
 	mux.Handle(HealthPath, http.HandlerFunc(o.health))

--- a/pkg/util/trace_utils.go
+++ b/pkg/util/trace_utils.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"context"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func TraceLogger(ctx context.Context) *log.Entry {
+	if ctx != nil {
+		span, exists := tracer.SpanFromContext(ctx)
+		if exists && span.Context().TraceID() != 0 {
+			traceID := span.Context().TraceID()
+			spanID := span.Context().SpanID()
+			return log.WithFields(log.Fields{
+				"dd.trace_id": traceID,
+				"dd.span_id":  spanID,
+			})
+		}
+	}
+	// add a field to indicate that this logger doesn't have any context, and thus no traceID/spanID
+	return log.WithField("dd.no_trace", "")
+}


### PR DESCRIPTION
Enables DataDog APM with automated instrumentation with association between logs and traceID/spanID.

This is a first step. More spans (at lower level) will be added later.

See https://github.com/cloudbees/arcalos/issues/489