### PR TITLE
feat: propagate context to tenant-service calls

### DIFF
--- a/pkg/hook/handle_webhook.go
+++ b/pkg/hook/handle_webhook.go
@@ -57,7 +57,7 @@ func (o *HookOptions) handleWebHookRequests(w http.ResponseWriter, r *http.Reque
 		}
 		l = l.WithField("Installation", installHook.Installation.ID)
 		l.Info("invoking Installation handler")
-		err = o.onInstallHook(l, installHook)
+		err = o.onInstallHook(r.Context(), l, installHook)
 		if err != nil {
 			responseHTTPError(w, http.StatusInternalServerError, "500 Internal Server Error: %s", err.Error())
 		} else {
@@ -74,7 +74,7 @@ func (o *HookOptions) handleWebHookRequests(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	err = o.onGeneralHook(l, installRef, webhook)
+	err = o.onGeneralHook(r.Context(), l, installRef, webhook)
 	if err != nil {
 		l.WithError(err).Error("failed to process webook")
 

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -132,7 +132,7 @@ func (o *HookOptions) isReady() bool {
 	return true
 }
 
-func (o *HookOptions) onInstallHook(log *logrus.Entry, hook *scm.InstallationHook) error {
+func (o *HookOptions) onInstallHook(ctx context.Context, log *logrus.Entry, hook *scm.InstallationHook) error {
 	install := hook.Installation
 	id := install.ID
 	fields := map[string]interface{}{
@@ -172,16 +172,16 @@ func (o *HookOptions) onInstallHook(log *logrus.Entry, hook *scm.InstallationHoo
 
 			}
 		*/
-		return o.tenantService.AppInstall(log, id, ownerURL)
+		return o.tenantService.AppInstall(ctx, log, id, ownerURL)
 	} else if hook.Action == scm.ActionDelete {
-		return o.tenantService.AppUnnstall(log, id)
+		return o.tenantService.AppUnnstall(ctx, log, id)
 	} else {
 		log.Warnf("ignore unknown action")
 		return nil
 	}
 }
 
-func (o *HookOptions) onGeneralHook(log *logrus.Entry, install *scm.InstallationRef, webhook scm.Webhook) error {
+func (o *HookOptions) onGeneralHook(ctx context.Context, log *logrus.Entry, install *scm.InstallationRef, webhook scm.Webhook) error {
 	id := install.ID
 	repo := webhook.Repository()
 	// TODO this should be fixed in go-scm
@@ -199,7 +199,7 @@ func (o *HookOptions) onGeneralHook(log *logrus.Entry, install *scm.Installation
 		return nil
 	}
 	log.Infof("onGeneralHook")
-	workspaces, err := o.tenantService.FindWorkspaces(log, id, u)
+	workspaces, err := o.tenantService.FindWorkspaces(ctx, log, id, u)
 	if err != nil {
 		return err
 	}

--- a/pkg/hook/scm.go
+++ b/pkg/hook/scm.go
@@ -48,7 +48,7 @@ func (o *HookOptions) getInstallScmClient(log *logrus.Entry, ctx context.Context
 		}
 	}
 
-	tokenResource, err := o.tenantService.GetGithubAppToken(log, ref.ID)
+	tokenResource, err := o.tenantService.GetGithubAppToken(ctx, log, ref.ID)
 	if err != nil {
 		return nil, tokenResource, errors.Wrapf(err, "failed to get the GitHub App token for installation %s", key)
 	}

--- a/pkg/hook/tenant_service.go
+++ b/pkg/hook/tenant_service.go
@@ -26,9 +26,8 @@ func NewTenantService(host string) *TenantService {
 }
 
 // AppInstall registers an app installation on a number of repos
-func (t *TenantService) AppInstall(log *logrus.Entry, installationID int64, ownerURL string) error {
+func (t *TenantService) AppInstall(ctx context.Context, log *logrus.Entry, installationID int64, ownerURL string) error {
 	path := installationPath(installationID)
-	ctx := context.Background()
 	payload := &client.InstallAppRequest{
 		OwnerURL: &ownerURL,
 	}
@@ -42,10 +41,8 @@ func (t *TenantService) AppInstall(log *logrus.Entry, installationID int64, owne
 }
 
 // AppUnnstall removes an App installation
-func (t *TenantService) AppUnnstall(log *logrus.Entry, installationID int64) error {
+func (t *TenantService) AppUnnstall(ctx context.Context, log *logrus.Entry, installationID int64) error {
 	path := installationPath(installationID)
-	ctx := context.Background()
-
 	_, err := t.client.DeleteGitHubAppInstallGithubApp(ctx, path)
 	if err != nil {
 		log.WithError(err).Error("failed to uninstall app")
@@ -55,9 +52,8 @@ func (t *TenantService) AppUnnstall(log *logrus.Entry, installationID int64) err
 	return nil
 }
 
-func (t *TenantService) FindWorkspaces(log *logrus.Entry, installationID int64, gitURL string) ([]*access.WorkspaceAccess, error) {
+func (t *TenantService) FindWorkspaces(ctx context.Context, log *logrus.Entry, installationID int64, gitURL string) ([]*access.WorkspaceAccess, error) {
 	path := client.GetRepositoryWorkspacesWorkspacesPath()
-	ctx := context.Background()
 	installation := model.Int64ToA(installationID)
 	resp, err := t.client.GetRepositoryWorkspacesWorkspaces(ctx, path, &gitURL, &installation)
 	if err != nil {
@@ -73,10 +69,9 @@ func (t *TenantService) FindWorkspaces(log *logrus.Entry, installationID int64, 
 }
 
 // GetGithubAppToken returns the github app token for the installation
-func (t *TenantService) GetGithubAppToken(log *logrus.Entry, installationID int64) (*domain.InstallationToken, error) {
+func (t *TenantService) GetGithubAppToken(ctx context.Context, log *logrus.Entry, installationID int64) (*domain.InstallationToken, error) {
 	installation := model.Int64ToA(installationID)
 	path := client.GetGithubAppTokenWorkspacesPath(installation)
-	ctx := context.Background()
 	resp, err := t.client.GetGithubAppTokenWorkspaces(ctx, path)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to get GitHub App token")


### PR DESCRIPTION
The Context needs to be properly propagated so that we can enable distributed tracing by injecting/extracting APM trace context into request headers.

See https://github.com/cloudbees/arcalos/issues/493
Relates to https://github.com/cloudbees/jx-tenant-service/pull/376