### PR TITLE
fix: Retry webhook relay for "repository not configured"

### DIFF
--- a/pkg/hook/handle_webhook.go
+++ b/pkg/hook/handle_webhook.go
@@ -90,7 +90,8 @@ func (o *HookOptions) handleWebHookRequests(w http.ResponseWriter, r *http.Reque
 	}
 
 	githubDeliveryEvent := r.Header.Get("X-GitHub-Delivery")
-	duration := time.Second * 30
+	// Allow for two or three retries due to repository not configured.
+	duration := time.Second * 90
 	err = retry(duration, func() error {
 		return o.onGeneralHook(r.Context(), l, installRef, webhook, githubDeliveryEvent, bodyBytes)
 	}, func(e error, d time.Duration) {


### PR DESCRIPTION
Depends on https://github.com/jenkins-x/lighthouse/pull/613 to actually do anything.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>