### PR TITLE
fix: Don't even try to check if repo has installation if no repo is given

### DIFF
--- a/pkg/hook/github_app.go
+++ b/pkg/hook/github_app.go
@@ -55,15 +55,20 @@ func (o *GithubApp) handleInstalledRequests(w http.ResponseWriter, r *http.Reque
 
 	githubAppResponse := &GithubAppResponse{}
 
-	installation, response, err := o.findRepositoryInstallation(scmClient, owner, repository)
+	var response *scm.Response
+	var installation *scm.Installation
 
-	if o.hasErrored(response, err) {
-		l.Errorf("error from repository installation %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	if repository != "" {
+		installation, response, err = o.findRepositoryInstallation(scmClient, owner, repository)
+
+		if o.hasErrored(response, err) {
+			l.Errorf("error from repository installation %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
-	if response.Status == 404 {
+	if response == nil || response.Status == 404 {
 		l.Debugf("didn't find the installation via the repository trying organisation")
 		installation, response, err = scmClient.Apps.GetOrganisationInstallation(o.ctx, owner)
 		if o.hasErrored(response, err) {


### PR DESCRIPTION
This apparently results in `Bad credentials` as the return error, which is, y'know, not ideal. So let's only bother to check that if we have a repository.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>