### PR TITLE
fix: Pass X-GitHub-Event directly, not deduced from webhook kind

### DIFF
--- a/pkg/hook/handle_webhook.go
+++ b/pkg/hook/handle_webhook.go
@@ -88,7 +88,8 @@ func (o *HookOptions) handleWebHookRequests(w http.ResponseWriter, r *http.Reque
 	}
 
 	githubDeliveryEvent := r.Header.Get("X-GitHub-Delivery")
-	err = o.onGeneralHook(r.Context(), l, installRef, webhook, githubDeliveryEvent, bodyBytes)
+	githubEventType := r.Header.Get("X-GitHub-Event")
+	err = o.onGeneralHook(r.Context(), l, installRef, webhook, githubEventType, githubDeliveryEvent, bodyBytes)
 
 	if err != nil {
 		l.WithError(err).Errorf("failed to process webhook for '%s'", repository.FullName)


### PR DESCRIPTION
Because the webhook kind isn't exactly a perfect map to the `X-GitHub-Event` value in certain cases (namely creation/deletion of branches/tags), we end up with a spam of unknown webhook parse errors on the Lighthouse side. They're harmless but annoying.
