### PR TITLE
chore: use sha256 rather than sha1 for hmac signing

### DIFF
--- a/pkg/hmac/generator.go
+++ b/pkg/hmac/generator.go
@@ -3,23 +3,35 @@ package hmac
 import (
 	"crypto/hmac"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"strings"
 
 	"github.com/jenkins-x/jx-logging/pkg/log"
 )
 
 type Generator struct {
+	algo string
 	secret []byte
 }
 
-func NewGenerator(s []byte) *Generator {
-	return &Generator{s}
+func NewGenerator(algo string, s []byte) *Generator {
+	return &Generator{algo: algo, secret: s}
 }
 
 func (g *Generator) SignBody(body []byte) []byte {
-	computed := hmac.New(sha1.New, g.secret)
+	var computed hash.Hash
+	switch g.algo {
+	case "sha1":
+		computed = hmac.New(sha1.New, g.secret)
+	case "sha256":
+		computed = hmac.New(sha256.New, g.secret)
+	default:
+		panic("unknown algorithum")
+	}
+
 	_, err := computed.Write(body)
 	if err != nil {
 		log.Logger().Errorf("unable to write to hmac: %s", err)
@@ -30,19 +42,30 @@ func (g *Generator) SignBody(body []byte) []byte {
 func (g *Generator) HubSignature(body []byte) string {
 	signature := g.SignBody(body)
 	signatureString := fmt.Sprintf("%x", signature)
-	return fmt.Sprintf("sha1=%s", signatureString)
+	return fmt.Sprintf("%s=%s", g.algo, signatureString)
 }
 
 func (g *Generator) VerifySignature(signature string, body []byte) bool {
-	const signaturePrefix = "sha1="
-	const signatureLength = 45 // len(SignaturePrefix) + len(hex(sha1))
+	signaturePrefix := fmt.Sprintf("%s=", g.algo)
+
+	var signatureLength int // len(SignaturePrefix) + len(hex(sha1))
+	var actual []byte
+	switch g.algo {
+	case "sha1":
+		signatureLength = 45
+		actual = make([]byte, 20)
+	case "sha256":
+		signatureLength = 71
+		actual = make([]byte, 32)
+	default:
+		panic("unknown algorithum")
+	}
 
 	if len(signature) != signatureLength || !strings.HasPrefix(signature, signaturePrefix) {
 		return false
 	}
 
-	actual := make([]byte, 20)
-	_, err := hex.Decode(actual, []byte(signature[5:]))
+	_, err := hex.Decode(actual, []byte(signature[len(signaturePrefix):]))
 	if err != nil {
 		log.Logger().Errorf("unable to decode: %s", err)
 		return false

--- a/pkg/hmac/generator.go
+++ b/pkg/hmac/generator.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Generator struct {
-	algo string
+	algo   string
 	secret []byte
 }
 
@@ -29,7 +29,7 @@ func (g *Generator) SignBody(body []byte) []byte {
 	case "sha256":
 		computed = hmac.New(sha256.New, g.secret)
 	default:
-		panic("unknown algorithum")
+		panic("unknown algorithm")
 	}
 
 	_, err := computed.Write(body)
@@ -58,7 +58,7 @@ func (g *Generator) VerifySignature(signature string, body []byte) bool {
 		signatureLength = 71
 		actual = make([]byte, 32)
 	default:
-		panic("unknown algorithum")
+		panic("unknown algorithm")
 	}
 
 	if len(signature) != signatureLength || !strings.HasPrefix(signature, signaturePrefix) {

--- a/pkg/hmac/generator_test.go
+++ b/pkg/hmac/generator_test.go
@@ -6,19 +6,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateHmacSignature(t *testing.T) {
+func TestGenerateHmacSignatureSha1(t *testing.T) {
 	key := "this is the key"
 	body := "this is a much longer message body"
 
-	AssertSignature(t, []byte(key), []byte(body))
+	g := NewGenerator("sha1", []byte(key))
+
+	AssertSignature(t, g, []byte(body))
 }
 
-func AssertSignature(t *testing.T, secret, body []byte) {
-	g := NewGenerator(secret)
+func TestGenerateHmacSignatureSha256(t *testing.T) {
+	key := "this is the key"
+	body := "this is a much longer message body"
 
+	g := NewGenerator("sha256", []byte(key))
+
+	AssertSignature(t, g, []byte(body))
+}
+
+
+
+func AssertSignature(t *testing.T, g *Generator, body []byte) {
 	signature := g.HubSignature(body)
 	assert.NotEmpty(t, signature)
 	t.Logf("signature = '%s'", signature)
 
 	assert.True(t, g.VerifySignature(signature, body))
 }
+

--- a/pkg/hmac/generator_test.go
+++ b/pkg/hmac/generator_test.go
@@ -24,8 +24,6 @@ func TestGenerateHmacSignatureSha256(t *testing.T) {
 	AssertSignature(t, g, []byte(body))
 }
 
-
-
 func AssertSignature(t *testing.T, g *Generator, body []byte) {
 	signature := g.HubSignature(body)
 	assert.NotEmpty(t, signature)
@@ -33,4 +31,3 @@ func AssertSignature(t *testing.T, g *Generator, body []byte) {
 
 	assert.True(t, g.VerifySignature(signature, body))
 }
-

--- a/pkg/hook/handle_webhook_test.go
+++ b/pkg/hook/handle_webhook_test.go
@@ -39,7 +39,7 @@ func TestWebhooks(t *testing.T) {
 				// Test request parameters
 				assert.Equal(t, req.URL.String(), "/")
 
-				assert.Equal(t, req.Header.Get("X-Hub-Signature"), "sha1=cedda785b4dd580b72f0d4fa92a9697125372c15")
+				assert.Equal(t, req.Header.Get("X-Hub-Signature"), "sha256=99a6c7b0894b25577f26d06d94c320bc5e234ae72e414b038436877ccef02652")
 				// Send response to be tested
 				_, err := rw.Write([]byte(`OK`))
 				assert.NoError(t, err)
@@ -66,7 +66,7 @@ func TestWebhooks(t *testing.T) {
 				// Test request parameters
 				assert.Equal(t, req.URL.String(), "/")
 
-				assert.Equal(t, req.Header.Get("X-Hub-Signature"), "sha1=cedda785b4dd580b72f0d4fa92a9697125372c15")
+				assert.Equal(t, req.Header.Get("X-Hub-Signature"), "sha256=99a6c7b0894b25577f26d06d94c320bc5e234ae72e414b038436877ccef02652")
 				// Send response to be tested
 				rw.WriteHeader(500)
 				_, err := rw.Write([]byte(repoNotConfiguredMessage))
@@ -84,7 +84,7 @@ func TestWebhooks(t *testing.T) {
 				// Test request parameters
 				assert.Equal(t, req.URL.String(), "/")
 
-				assert.Equal(t, req.Header.Get("X-Hub-Signature"), "sha1=cedda785b4dd580b72f0d4fa92a9697125372c15")
+				assert.Equal(t, req.Header.Get("X-Hub-Signature"), "sha256=99a6c7b0894b25577f26d06d94c320bc5e234ae72e414b038436877ccef02652")
 				// Send response to be tested
 				rw.WriteHeader(500)
 				_, err := rw.Write([]byte(`not ok`))

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -272,7 +272,7 @@ func (o *HookOptions) onGeneralHook(ctx context.Context, log *logrus.Entry, inst
 func (o *HookOptions) retryWebhookDelivery(lighthouseURL string, githubEventType string, githubDeliveryEvent string, decodedHmac []byte, useInsecureRelay bool, bodyBytes []byte, log *logrus.Entry) error {
 	f := func() error {
 		log.Debugf("relaying %s", string(bodyBytes))
-		g := hmac.NewGenerator(decodedHmac)
+		g := hmac.NewGenerator("sha256", decodedHmac)
 		signature := g.HubSignature(bodyBytes)
 
 		var httpClient *http.Client


### PR DESCRIPTION
fixes cloudbees/arcalos-security#38